### PR TITLE
Add DISCORD_TOKEN to .env in CI/CD workflow

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
+      - name: Add DISCORD_TOKEN to .env
+        run: echo "DISCORD_TOKEN=${{ secrets.DISCORD_TOKEN }}" >> ./backend/.env
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci_cd.yml` file. The change adds a step to include the `DISCORD_TOKEN` in the `.env` file for the backend.

* [`.github/workflows/ci_cd.yml`](diffhunk://#diff-c80d54cb778b5196ee7b73e152870cac313eed095f65886e3f15247cdc900d1aR13-R14): Added a step to add `DISCORD_TOKEN` to the `.env` file for the backend.